### PR TITLE
Keyboard shortcut to clear scrollback buffer

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -149,7 +149,7 @@ bind-key C-l resize-pane -R
 # use vim motion keys while in copy mode
 setw -g mode-keys vi
 
-# clear scrollback with cmd-b (handy for log panes)
+# clear scrollback with ctrl-b (handy for log panes)
 # via http://stackoverflow.com/a/11525159
 bind -n C-b send-keys -R \; clear-history
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -149,6 +149,10 @@ bind-key C-l resize-pane -R
 # use vim motion keys while in copy mode
 setw -g mode-keys vi
 
+# clear scrollback with cmd-b (handy for log panes)
+# via http://stackoverflow.com/a/11525159
+bind -n C-b send-keys -R \; clear-history
+
 ############################################################################
 # layouts
 ############################################################################

--- a/README.md
+++ b/README.md
@@ -1,49 +1,37 @@
 Open iTerm2
 
-Install Fish: - brew install fish
-
-Install Tmux: - brew install tmux
-
-Install Tmuxinator: gem install tmuxinator
-
-
-cp working.yml ~/.tmuxinator/working.yml
-
-cp .tmux.conf ~/.tmux.conf
-
-cp config.fish ~/.config/fish/config.fish
+1. Install Fish: - `brew install fish`
+2. Install Tmux: - `brew install tmux`
+3. Install Tmuxinator: `gem install tmuxinator`
+4. `cp working.yml ~/.tmuxinator/working.yml`
+5. `cp .tmux.conf ~/.tmux.conf`
+6. `cp config.fish ~/.config/fish/config.fish`
 
 
 In command prompt:
 
+```
 fish
-
 mux start working
-
-
-
-
+```
 
 cp .tmux.config ~/
 cp .fish.config ~/
 cp working.yaml ~/…
 
-ctrl + a n - goes to next window
-ctrl + a p - goes to previous window
+* `ctrl + a n` - goes to next window
+* `ctrl + a p` - goes to previous window
+* `ctrl + a |`  - creates a vertical divider
+* `ctrl + a -`  - creates a horizontal divider
 
-ctrl + a |  - creates a vertical divider
-ctrl + a -  - creates a horizontal divider
+* `ctrl + a 0` - goes to window 0, `ctrl + a 1` - goes to window 1 (etc..)
 
-ctrl + a 0 - goes to window 0
-ctrl + a 1 - goes to window 1 (etc..)
+* `ctrl + a j` - down a pane
+* `ctrl + a k` - up a pane
+* `ctrl + a h` - left a pane
+* `ctrl + a l` - right a pane
 
-
-ctrl + a  j- down a pane
-ctrl + a k - up a pane
-ctrl + a h - left a pane
-ctrl + a l - rigth a pane
-
-`ctrl-k` - clear scrollback buffer for a pane
+* `ctrl-k` - clear scrollback buffer for a pane
 
 Optional:
 Tip: Map Capslock key to Ctrl key for easy Caps+ a

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ctrl + a k - up a pane
 ctrl + a h - left a pane
 ctrl + a l - rigth a pane
 
+`ctrl-k` - clear scrollback buffer for a pane
 
 Optional:
 Tip: Map Capslock key to Ctrl key for easy Caps+ a


### PR DESCRIPTION
Handy shortcut (ctrl-b) for clearing log panes (instead of hitting enter a bunch of times or adding a bunch of characters).

This also includes some cleanup of the README so it looks better on Github.
